### PR TITLE
Bump tflint-plugin-sdk to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a template repository for building a custom ruleset. You can create a pl
 
 ## Requirements
 
-- TFLint v0.17+
+- TFLint v0.18+
 - Go v1.14
 
 ## Installation
@@ -25,6 +25,7 @@ plugin "template" {
 |aws_instance_example_type|Example rule for accessing and evaluating top-level attributes|ERROR|✔||
 |aws_s3_bucket_example_lifecycle_rule|Example rule for accessing top-level/nested blocks and attributes under blocks|ERROR|✔||
 |local_file_example_provisioner|Example rule for accessing reserved attributes/blocks such as "provisioner"|ERROR|✔||
+|terraform_backend_type|Example rule for accessing the backend configuration|ERROR|✔||
 
 ## Building the plugin
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/hashicorp/hcl/v2 v2.6.0
-	github.com/terraform-linters/tflint-plugin-sdk v0.2.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/terraform-linters/tflint-plugin-sdk v0.2.0 h1:kLNBJatWgylUL1Iieys3DnaCVHChTMEqft5BW7+NVyk=
-github.com/terraform-linters/tflint-plugin-sdk v0.2.0/go.mod h1:QoSqSV/8GSOrQy3OStK3EEdsA3yZm13My4BQcnx3Zic=
+github.com/terraform-linters/tflint-plugin-sdk v0.3.0 h1:TUMBlM17mZKMzaZtp1KLj6T6BHLTunVQ/8f2cWOaMjY=
+github.com/terraform-linters/tflint-plugin-sdk v0.3.0/go.mod h1:QoSqSV/8GSOrQy3OStK3EEdsA3yZm13My4BQcnx3Zic=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/zclconf/go-cty v1.2.0 h1:sPHsy7ADcIZQP3vILvTjrh74ZA175TFP5vqiNK1UmlI=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 				rules.NewAwsInstanceExampleTypeRule(),
 				rules.NewAwsS3BucketExampleLifecycleRuleRule(),
 				rules.NewLocalFileExampleProvisionerRule(),
+				rules.NewTerraformBackendTypeRule(),
 			},
 		},
 	})

--- a/rules/terraform_backend_type.go
+++ b/rules/terraform_backend_type.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// TerraformBackendTypeRule checks whether ...
+type TerraformBackendTypeRule struct{}
+
+// NewTerraformBackendTypeRule returns a new rule
+func NewTerraformBackendTypeRule() *TerraformBackendTypeRule {
+	return &TerraformBackendTypeRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformBackendTypeRule) Name() string {
+	return "terraform_backend_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformBackendTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *TerraformBackendTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *TerraformBackendTypeRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *TerraformBackendTypeRule) Check(runner tflint.Runner) error {
+	backend, err := runner.Backend()
+	if err != nil {
+		return err
+	}
+	if backend == nil {
+		return nil
+	}
+
+	return runner.EmitIssue(
+		r,
+		fmt.Sprintf("backend type is %s", backend.Type),
+		backend.DeclRange,
+	)
+}

--- a/rules/terraform_backend_type_test.go
+++ b/rules/terraform_backend_type_test.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_TerraformBackendType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "issue found",
+			Content: `
+terraform {
+  backend "s3" {
+	bucket = "mybucket"
+	key    = "path/to/my/key"
+    region = "us-east-1"
+  }
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewTerraformBackendTypeRule(),
+					Message: "backend type is s3",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3},
+						End:      hcl.Pos{Line: 3, Column: 15},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewTerraformBackendTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
This PR is an example of upgrading tflint-plugin-sdk for ruleset plugin.

This brings the following changes:

- Added `Backend` to access the backend configuration
- Updated protocol version. This means all plugins will need to be rebuilt with the new SDK

For details, see the CHANGELOG of tflint-plugin-sdk.