### PR TITLE
build: Add arm64 GOARCH

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
       - 386
       - amd64
       - arm
+      - arm64
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
This PR adds `arm64` as GOARCH to support darwin/arm64 (Apple M1) build.