### PR TITLE
build: Remove unsupported build targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,18 +3,15 @@
 env:
   - CGO_ENABLED=0
 builds:
-  - goos:
-      - linux
-      - darwin
-      - freebsd
-      - netbsd
-      - openbsd
-      - windows
-    goarch:
-      - 386
-      - amd64
-      - arm
-      - arm64
+  - targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_386
+      - linux_amd64
+      - linux_arm
+      - linux_arm64
+      - windows_386
+      - windows_amd64
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1220

TFLint v0.33 no longer supports prebuilt binaries for some OS/arch. Change the build target that the plugin also supports accordingly.