### PR TITLE
Improve onboarding process

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is a template repository for building a custom ruleset. You can create a pl
 
 ## Installation
 
+TODO: This template repository does not contain release binaries, so this installation will not work. Please rewrite for your repository. See the "Building the plugin" section to get this template ruleset working.
+
 You can install the plugin with `tflint --init`. Declare a config in `.tflint.hcl` as follows:
 
 ```hcl
@@ -50,4 +52,15 @@ You can easily install the built plugin with the following:
 
 ```
 $ make install
+```
+
+You can run the built plugin like the following:
+
+```
+$ cat << EOS > .tflint.hcl
+plugin "template" {
+  enabled = true
+}
+EOS
+$ tflint
 ```

--- a/rules/google_compute_ssl_policy.go
+++ b/rules/google_compute_ssl_policy.go
@@ -29,7 +29,8 @@ func (r *GoogleComputeSSLPolicyRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *GoogleComputeSSLPolicyRule) Enabled() bool {
-	return true
+	// Need to configure `allowed_versions`
+	return false
 }
 
 // Severity returns the rule severity


### PR DESCRIPTION
- Add TODO comments for "Installation" section in README.
  - Explain that this installation step does not work out of the box.
- Add an example of running the ruleset plugin.
- Disable `google_compute_ssl_policy` rule by default.
  - This rule does not work by default because it returns "rule `google_compute_ssl_policy` is not found in config" error.