### PR TITLE
Add permissions to create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     tags:
     - v*.*.*
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To create a release, `contents: write` permission is required. Since the current template does not have this permission, the workflow fails to create a release.

Add this permission to enable the creation of releases.
Additionally, to align with other repositories(such as tflint-ruleset-aws), add `id-token: write` permission.