### PR TITLE
Add raw binary entries to checksums.txt

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,10 @@ builds:
       - linux_arm64
       - windows_386
       - windows_amd64
+    hooks:
+      post:
+        - mkdir -p ./dist/raw
+        - cp "{{ .Path }}" "./dist/raw/{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
@@ -20,6 +24,8 @@ archives:
       - none*
 checksum:
   name_template: 'checksums.txt'
+  extra_files:
+    - glob: ./dist/raw/*
 signs:
   - artifacts: checksum
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-aws/pull/523

Make `checksums.txt` included in releases contain checksums for raw binaries instead of archives for future dependency lockfile introductions.

By default, the `checksum` step only checksums archives, so `extra_files` is used.