### PR TITLE
Avoid tracking built binary in `git`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# don't track built binary
+/tflint-ruleset-template


### PR DESCRIPTION
I.e. ignore the output of `make build`, otherwise running that command will result in an untracked file which can add noise e.g. in the `git status` output