### PR TITLE
goreleaser: Fix deprecated `archives.format`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,8 @@ builds:
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    format: zip
+    formats:
+      - zip
     files:
       - none*
 checksum:


### PR DESCRIPTION
See https://goreleaser.com/deprecations/#archivesformat